### PR TITLE
Unset the paginator property when there are no more results

### DIFF
--- a/src/RequestBuilder.php
+++ b/src/RequestBuilder.php
@@ -928,6 +928,12 @@ class RequestBuilder {
             $this->paginator = new Paginator($this, 1, $pageSize);
         }
 
-        return $this->paginator->page();
+        $results = $this->paginator->page();
+
+        if ($results === false) {
+            unset($this->paginator);
+        }
+
+        return $results;
     }
 }


### PR DESCRIPTION
This way it will be reinstantiated the next time the same builder instance gets used